### PR TITLE
Assigning multiple IP addresses to a non-VNET jail

### DIFF
--- a/jail/__init__.py
+++ b/jail/__init__.py
@@ -162,11 +162,12 @@ class IovecValue:
         #return f"<{self.__class__.__name__}: \"{str(self)}\">"
 
     def __len__(self) -> int:
-        if self.value is None:
+        value = self.value
+        if value is None:
             return 0
-        elif isinstance(self.value, int):
+        elif isinstance(value, int):
             return ctypes.sizeof(ctypes.c_int)
-        return len(self.value)
+        return len(value)
 
     def __str__(self) -> str:
         if isinstance(self.value, bytes) is True:

--- a/jail/__init__.py
+++ b/jail/__init__.py
@@ -215,7 +215,7 @@ class IovecValue:
                     ctypes.POINTER(output_type)(self.value),
                     ctypes.c_void_p
                 ),
-                ctypes.sizeof(output_type)
+                ctypes.sizeof(output_type * len(self._value))
             )
 
         else:


### PR DESCRIPTION
It is not possible to assign multiple IP addresses to a non-VNET jail.