### PR TITLE
Make the package importable outside FreeBSD

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,18 @@ jobs:
       - run: python -m build
       - run: python -m twine check dist/*
 
+  test-linux:
+    name: Unit tests on Linux
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+      - run: python -m pip install pytest pytest-benchmark "freebsd-sysctl @ git+https://github.com/gronke/py-freebsd_sysctl@92f6cf5dd4cab3a9b7e4ef04c4ca0dbeec74e181"
+      - run: python -m pip install --no-deps .
+      - run: python -m pytest tests/IovecValue_test.py tests/Jiov_test.py -v --benchmark-disable
+
   test-freebsd:
     name: Test on FreeBSD ${{ matrix.release }}
     runs-on: ubuntu-latest

--- a/jail/__init__.py
+++ b/jail/__init__.py
@@ -32,10 +32,28 @@ import freebsd_sysctl.types
 
 from jail.__version__ import __version__
 from jail.libc import dll
+import jail.libc
 import jail.types
 
 NULL_BYTES = b"\x00"
-JAIL_MAX_AF_IPS = freebsd_sysctl.Sysctl("security.jail.jail_max_af_ips").value
+_JAIL_MAX_AF_IPS: typing.Optional[int] = None
+
+
+def _jail_max_af_ips() -> int:
+    global _JAIL_MAX_AF_IPS
+    if _JAIL_MAX_AF_IPS is None:
+        _JAIL_MAX_AF_IPS = int(
+            freebsd_sysctl.Sysctl("security.jail.jail_max_af_ips").value
+        )
+    return _JAIL_MAX_AF_IPS
+
+
+def __getattr__(name: str) -> typing.Any:
+    # JAIL_MAX_AF_IPS reads a sysctl, so it resolves on first access to
+    # keep the module importable on other platforms
+    if name == "JAIL_MAX_AF_IPS":
+        return _jail_max_af_ips()
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
 class Iovec(ctypes.Structure):
@@ -118,7 +136,7 @@ class IovecValue:
         if isinstance(value, list):
             if len(value) == 0:
                 return None
-            elif len(value) > JAIL_MAX_AF_IPS:
+            elif len(value) > _jail_max_af_ips():
                 raise ValueError("Too many IPs (max {JAIL_MAX_AF_IPS}")
             elif isinstance(value[0], ipaddress.IPv4Address):
                 list_type = jail.types.in_addr
@@ -381,12 +399,12 @@ def get_jid_by_name(name: typing.Union[str, bytes]) -> int:
         raise TypeError("bytes required")
 
     jiov = jail.Jiov(dict(name=name))
-    return int(jail.dll.jail_get(jiov.pointer, len(jiov), 0))
+    return jail.libc.jail_get(jiov.pointer, len(jiov), 0)
 
 def is_jid_dying(jid: int) -> bool:
     jiov = jail.Jiov(dict(jid=jid,dying=0))
     JAIL_DYING = 0x08
-    if jail.dll.jail_get(jiov.pointer, len(jiov), JAIL_DYING) < 0:
+    if jail.libc.jail_get(jiov.pointer, len(jiov), JAIL_DYING) < 0:
         return False  # jid does not exist
     return (int(jiov[IovecKey("dying")]) > 0) is True
 

--- a/jail/libc.py
+++ b/jail/libc.py
@@ -23,8 +23,46 @@
 # POSSIBILITY OF SUCH DAMAGE.
 """libc abstraction."""
 import ctypes
+import typing
+
 try:
-    dll = ctypes.CDLL("libc.so.7")
+    dll = ctypes.CDLL("libc.so.7", use_errno=True)
 except OSError:
     import ctypes.util
     dll = ctypes.CDLL(str(ctypes.util.find_library("c")), use_errno=True)
+
+_ARGTYPES = {
+    "jail_get": [ctypes.c_void_p, ctypes.c_uint, ctypes.c_int],
+    "jail_set": [ctypes.c_void_p, ctypes.c_uint, ctypes.c_int],
+    "jail_attach": [ctypes.c_int],
+    "jail_remove": [ctypes.c_int]
+}
+_prototypes: typing.Dict[str, typing.Any] = {}
+
+
+def _jail_func(name: str) -> typing.Any:
+    # the jail(2) family only exists in FreeBSD's libc, so each symbol is
+    # resolved on first use to keep the module importable on other platforms
+    prototype = _prototypes.get(name)
+    if prototype is None:
+        prototype = getattr(dll, name)
+        prototype.argtypes = _ARGTYPES[name]
+        prototype.restype = ctypes.c_int
+        _prototypes[name] = prototype
+    return prototype
+
+
+def jail_get(iov: typing.Any, niov: int, flags: int) -> int:
+    return int(_jail_func("jail_get")(iov, niov, flags))
+
+
+def jail_set(iov: typing.Any, niov: int, flags: int) -> int:
+    return int(_jail_func("jail_set")(iov, niov, flags))
+
+
+def jail_attach(jid: int) -> int:
+    return int(_jail_func("jail_attach")(jid))
+
+
+def jail_remove(jid: int) -> int:
+    return int(_jail_func("jail_remove")(jid))


### PR DESCRIPTION
Importing jail executed a sysctl, so the package only loaded on FreeBSD and no unit test could run anywhere else.

- Importing no longer touches the kernel: `JAIL_MAX_AF_IPS` is read on first access and cached, keeping its public name.
- The `jail(2)` functions get ctypes prototypes with errno support, resolved on first use like in freebsd_sysctl — groundwork for raising OSError on failures in a follow-up.
- CI gains a Linux job running the marshalling unit tests, all of which now pass off FreeBSD; freebsd-sysctl installs from git until 0.1.0 reaches PyPI.
- Behavior on FreeBSD is unchanged: `JAIL_MAX_AF_IPS` and raw `jail.dll` access work as before.