### PR TITLE
Run the test suite on FreeBSD VMs on GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,45 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  build:
+    name: Build distribution
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+      - run: python -m pip install build twine
+      - run: python -m build
+      - run: python -m twine check dist/*
+
+  test-freebsd:
+    name: Test on FreeBSD ${{ matrix.release }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        release: ["14.4-RELEASE", "15.1-RELEASE"]
+    steps:
+      - uses: actions/checkout@v7
+      - name: Setup the VM
+        uses: gronke/freebsd-ci/.github/actions/setup-vm@16b835a34634c4d68d7f382df7f107f227aae26b
+        with:
+          version: ${{ matrix.release }}
+      - name: Run the test suite in the guest
+        uses: gronke/freebsd-ci/.github/actions/run@16b835a34634c4d68d7f382df7f107f227aae26b
+        with:
+          run: |
+            env ASSUME_ALWAYS_YES=yes pkg bootstrap -f >/dev/null
+            pkg install -qy python3
+            PY_SUFFIX=$(python3 -c 'import sys; print(f"py{sys.version_info[0]}{sys.version_info[1]}")')
+            pkg install -qy "${PY_SUFFIX}-freebsd-sysctl" "${PY_SUFFIX}-pip" "${PY_SUFFIX}-pytest" "${PY_SUFFIX}-pytest-benchmark"
+            python3 -m pip install --no-deps .
+            python3 -m pytest tests -v --benchmark-disable

--- a/tests/jail_test.py
+++ b/tests/jail_test.py
@@ -78,7 +78,7 @@ def test_configure_ipv4_addresses_for_non_vnet_jail(
     bridge_interface: str
 ) -> None:
     subprocess.check_output(
-        [ifconfig_command, bridge_interface, "inet", str(ipv4_address)]
+        [ifconfig_command, bridge_interface, "inet", f"{ipv4_address}/24"]
     )
     jiov = jail.Jiov({
         "persist": None,
@@ -105,10 +105,10 @@ def test_configure_miltiple_ipv4_addresses_for_non_vnet_jail(
 
     print("IPS", str(ip1), str(ip2))
     subprocess.check_output(
-        [ifconfig_command, bridge_interface, "inet", str(ip1), "alias"]
+        [ifconfig_command, bridge_interface, "inet", f"{ip1}/24", "alias"]
     )
     subprocess.check_output(
-        [ifconfig_command, bridge_interface, "inet", str(ip2), "alias"]
+        [ifconfig_command, bridge_interface, "inet", f"{ip2}/32", "alias"]
     )
     jiov = jail.Jiov({
         "persist": None,


### PR DESCRIPTION
The project never had working CI; this runs the test suite inside real FreeBSD VMs on every push and pull request.

- The test matrix boots FreeBSD 14.4-RELEASE and 15.1-RELEASE under QEMU through the composite actions from gronke/freebsd-ci, pinned to a commit until a versioned tag exists.
- The guest installs python, freebsd-sysctl, pip and pytest from packages, installs the library through pip and runs the whole suite — proving that the package installs again since #9.
- A build job packages the sdist and wheel on Linux and validates the metadata with twine.
- FreeBSD 15 no longer accepts ifconfig addresses without a netmask; the two affected tests now pass explicit masks, and the full suite is green on both releases.
- Closes #2 and supersedes #4 by @igalic, whose Travis and Cirrus setup predates GitHub Actions.