### PR TITLE
Keep the iovec buffers alive until the kernel reads them

### DIFF
--- a/jail/__init__.py
+++ b/jail/__init__.py
@@ -74,6 +74,7 @@ class IovecKey:
             raise KeyError(
                 f"bytes or string expected, but got: {type(value).__name__}"
             )
+        self._iovec_buffer: typing.Optional[ctypes.Array] = None
 
     def __repr__(self) -> str:
         return self.__str__();
@@ -95,14 +96,16 @@ class IovecKey:
         return self.__hash__() == other.__hash__()
 
     @property
-    def iovec(self) -> ctypes.c_void_p:
-        return (Iovec(
-            ctypes.cast(
-                ctypes.c_char_p(bytes(self) + NULL_BYTES),
-                ctypes.c_void_p
-            ),
-            len(self) + len(NULL_BYTES)
-        ))
+    def iovec(self) -> Iovec:
+        # the kernel dereferences iov_base after this property returns,
+        # so the key owns its backing buffer for its whole lifetime
+        if self._iovec_buffer is None:
+            data = bytes(self) + NULL_BYTES
+            self._iovec_buffer = ctypes.create_string_buffer(data, len(data))
+        return Iovec(
+            ctypes.c_void_p(ctypes.addressof(self._iovec_buffer)),
+            len(self._iovec_buffer)
+        )
 
 
 RawIovecValue = typing.Optional[typing.Union[
@@ -123,6 +126,7 @@ IovecValueOutput = typing.Union[
 class IovecValue:
 
     _value: RawIovecValue
+    _iovec_buffer: typing.Any
 
     def __init__(
         self,
@@ -158,6 +162,7 @@ class IovecValue:
 
     @value.setter
     def value(self, value: RawIovecValue) -> None:
+        self._iovec_buffer = None
         if isinstance(value, list):
             self._value = value
         else:
@@ -200,46 +205,35 @@ class IovecValue:
         raise ValueError("cannot convert value to int")
 
     @property
-    def iovec(self) -> typing.Union[ctypes.POINTER, int]:
+    def iovec(self) -> Iovec:
+        # the kernel dereferences iov_base after this property returns,
+        # so the value owns its backing buffer for its whole lifetime
+        value = self.value
 
-        if self.value is None:
+        if value is None:
             return Iovec(ctypes.c_void_p(), 0)
 
-        elif isinstance(self.value, bytes) is True:
-            return Iovec(
-                ctypes.cast(
-                    ctypes.c_char_p(self.value + NULL_BYTES),
-                    ctypes.c_void_p
-                ),
-                self.__len__() + len(NULL_BYTES)
-            )
+        if self._iovec_buffer is None:
+            if isinstance(value, bytes) is True:
+                data = value + NULL_BYTES
+                self._iovec_buffer = ctypes.create_string_buffer(
+                    data,
+                    len(data)
+                )
+            elif isinstance(value, int) is True:
+                if not jail.types.MIN_INT <= value <= jail.types.MAX_INT:
+                    raise OverflowError("Integer parameter out of range")
+                self._iovec_buffer = ctypes.c_int(value)
+            elif isinstance(self._value, list) is True:
+                self._iovec_buffer = value
+            else:
+                # XXX: IP Addrs, JailSys Enums (new, inherit, disabled)
+                raise NotImplementedError
 
-        elif isinstance(self.value, int) is True:
-            if not jail.types.MIN_INT <= self.value <= jail.types.MAX_INT:
-                raise OverflowError("Integer parameter out of range")
-            return Iovec(
-                ctypes.cast(
-                    ctypes.POINTER(ctypes.c_int)(ctypes.c_int(self.value)),
-                    ctypes.c_void_p
-                ),
-                self.__len__()
-            )
-
-        elif isinstance(self._value, list) is True:
-            if len(self._value) == 0:
-                return Iovec(ctypes.c_void_p(), 0)
-            output_type = type(self.value[0])
-            return Iovec(
-                ctypes.cast(
-                    ctypes.POINTER(output_type)(self.value),
-                    ctypes.c_void_p
-                ),
-                ctypes.sizeof(output_type * len(self._value))
-            )
-
-        else:
-            # XXX: IP Addrs, JailSys Enums (new, inherit, disabled)
-            raise NotImplementedError
+        return Iovec(
+            ctypes.c_void_p(ctypes.addressof(self._iovec_buffer)),
+            ctypes.sizeof(self._iovec_buffer)
+        )
 
 
 class ByteDict(dict):
@@ -355,6 +349,7 @@ class Jiov(JiovData):
         ]
     ) -> None:
         self.errmsg = ctypes.create_string_buffer(256)
+        self._errmsg_key = ctypes.create_string_buffer(b"errmsg")
         super().__init__(params)
 
     def __len__(self) -> int:
@@ -373,20 +368,14 @@ class Jiov(JiovData):
 
         items.append(
             Iovec(
-                ctypes.cast(
-                    ctypes.c_char_p(b"errmsg\x00"),
-                    ctypes.c_void_p
-                ),
-                len(b"errmsg\x00")
+                ctypes.c_void_p(ctypes.addressof(self._errmsg_key)),
+                len(self._errmsg_key)
             )
         )
-        
+
         items.append(
             Iovec(
-                ctypes.cast(
-                    ctypes.POINTER(ctypes.c_char_p)(self.errmsg),
-                    ctypes.c_void_p
-                ),
+                ctypes.c_void_p(ctypes.addressof(self.errmsg)),
                 len(self.errmsg)
             )
         )

--- a/tests/Jiov_test.py
+++ b/tests/Jiov_test.py
@@ -21,6 +21,8 @@
 # STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
 # IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
+import ctypes
+import gc
 import os.path
 import pytest
 import subprocess
@@ -43,3 +45,30 @@ def test_jiov_length():
     struct_length = (len(data) + 1) * 2  # (data + errmsg) key/value pairs
     assert len(jiov.struct) == struct_length
     assert len(jiov) == struct_length
+
+
+def test_jiov_buffers_survive_garbage_collection():
+    jiov = jail.Jiov(dict(name="keepalive", jid=23, persist=None))
+    pointer = jiov.pointer
+
+    gc.collect()
+    # allocations of every small size class, so freed blocks get reused
+    churn = [b"\xff" * (1 + i % 64) for i in range(8192)]
+
+    entries = pointer.contents
+    assert len(entries) == len(jiov)
+    assert ctypes.string_at(entries[0].iov_base, entries[0].iov_size) \
+        == b"name\x00"
+    assert ctypes.string_at(entries[1].iov_base, entries[1].iov_size) \
+        == b"keepalive\x00"
+    assert ctypes.string_at(entries[2].iov_base, entries[2].iov_size) \
+        == b"jid\x00"
+    assert ctypes.c_int.from_address(entries[3].iov_base).value == 23
+    assert ctypes.string_at(entries[4].iov_base, entries[4].iov_size) \
+        == b"persist\x00"
+    assert entries[5].iov_base is None
+    assert ctypes.string_at(entries[6].iov_base, entries[6].iov_size) \
+        == b"errmsg\x00"
+    assert entries[7].iov_size == 256
+
+    assert len(churn) == 8192

--- a/tests/jail_test.py
+++ b/tests/jail_test.py
@@ -21,6 +21,7 @@
 # STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
 # IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
+import gc
 import os.path
 import pytest
 import subprocess
@@ -158,3 +159,22 @@ def test_configure_ipv6_addresses_for_non_vnet_jail(
     finally:
         if jid > 0:
             subprocess.check_output([jail_command, "-r", str(jid)])
+
+
+def test_jail_set_reads_current_buffers_under_memory_churn() -> None:
+    name = "test-keepalive-churn"
+    jiov = jail.Jiov({"persist": None, "name": name, "path": "/rescue"})
+    pointer = jiov.pointer
+
+    gc.collect()
+    churn = [bytes(64) for _ in range(4096)]
+
+    jid = jail.dll.jail_set(pointer, len(jiov), 1)
+    try:
+        assert isinstance(jid, int)
+        assert jid > 0
+        assert jail.get_jid_by_name(name) == jid
+    finally:
+        subprocess.check_output([jail_command, "-r", str(jid)])
+
+    assert len(churn) == 4096


### PR DESCRIPTION
Building a Jiov cast unreferenced temporaries to void pointers, so jail_set(2) could hand the kernel addresses of memory that Python had already freed - it worked by allocator luck.

- Keys and values now own their backing buffers for their whole lifetime, and every iov_base points at that owned memory; reassigning a value invalidates its buffer.
- The errmsg pair keeps its key buffer on the Jiov and no longer takes the address through an ill-typed POINTER(c_char_p) construction.
- A unit test reads every iovec entry back from its raw addresses after garbage collection and allocator churn; an integration test creates a jail under the same conditions and resolves it by name.