### PR TITLE
Raise OSError on jail(2) failures with the kernel error message

### DIFF
--- a/jail/__init__.py
+++ b/jail/__init__.py
@@ -24,8 +24,10 @@
 """FreeBSD jail sysctl bindings."""
 import typing
 import ctypes
+import errno
 import itertools
 import ipaddress
+import os
 
 import freebsd_sysctl
 import freebsd_sysctl.types
@@ -54,6 +56,12 @@ def __getattr__(name: str) -> typing.Any:
     if name == "JAIL_MAX_AF_IPS":
         return _jail_max_af_ips()
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+JAIL_CREATE = 0x01
+JAIL_UPDATE = 0x02
+JAIL_ATTACH = 0x04
+JAIL_DYING = 0x08
 
 
 class Iovec(ctypes.Structure):
@@ -383,17 +391,61 @@ class Jiov(JiovData):
         return (Iovec * len(items))(*items)
 
 
+def _raise_jail_error(jiov: Jiov) -> typing.NoReturn:
+    code = ctypes.get_errno()
+    errmsg = jiov.errmsg.value.decode("UTF-8", "replace")
+    raise OSError(code, errmsg if errmsg else os.strerror(code))
+
+
+def jail_set(jiov: Jiov, flags: int = JAIL_CREATE) -> int:
+    """Create or update a jail and return its jid."""
+    jid = jail.libc.jail_set(jiov.pointer, len(jiov), flags)
+    if jid < 0:
+        _raise_jail_error(jiov)
+    return jid
+
+
+def jail_get(jiov: Jiov, flags: int = 0) -> int:
+    """Read the parameters of a jail into the Jiov and return its jid."""
+    jid = jail.libc.jail_get(jiov.pointer, len(jiov), flags)
+    if jid < 0:
+        _raise_jail_error(jiov)
+    return jid
+
+
+def jail_attach(jid: int) -> None:
+    """Imprison the current process into the jail."""
+    if jail.libc.jail_attach(jid) != 0:
+        code = ctypes.get_errno()
+        raise OSError(code, os.strerror(code))
+
+
+def jail_remove(jid: int) -> None:
+    """Remove the jail, killing all processes in it."""
+    if jail.libc.jail_remove(jid) != 0:
+        code = ctypes.get_errno()
+        raise OSError(code, os.strerror(code))
+
+
 def get_jid_by_name(name: typing.Union[str, bytes]) -> int:
     if (isinstance(name, str) or isinstance(name, bytes)) is False:
         raise TypeError("bytes required")
 
     jiov = jail.Jiov(dict(name=name))
-    return jail.libc.jail_get(jiov.pointer, len(jiov), 0)
+    try:
+        return jail_get(jiov)
+    except OSError as err:
+        if err.errno == errno.ENOENT:
+            return -1
+        raise
 
 def is_jid_dying(jid: int) -> bool:
     jiov = jail.Jiov(dict(jid=jid,dying=0))
-    JAIL_DYING = 0x08
-    if jail.libc.jail_get(jiov.pointer, len(jiov), JAIL_DYING) < 0:
-        return False  # jid does not exist
+    try:
+        jail_get(jiov, JAIL_DYING)
+    except OSError as err:
+        if err.errno == errno.ENOENT:
+            return False  # jid does not exist
+        raise
     return (int(jiov[IovecKey("dying")]) > 0) is True
 

--- a/tests/Jiov_test.py
+++ b/tests/Jiov_test.py
@@ -72,3 +72,10 @@ def test_jiov_buffers_survive_garbage_collection():
     assert entries[7].iov_size == 256
 
     assert len(churn) == 8192
+
+
+def test_jail_flag_constants():
+    assert jail.JAIL_CREATE == 0x01
+    assert jail.JAIL_UPDATE == 0x02
+    assert jail.JAIL_ATTACH == 0x04
+    assert jail.JAIL_DYING == 0x08

--- a/tests/jail_test.py
+++ b/tests/jail_test.py
@@ -21,6 +21,7 @@
 # STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
 # IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
+import errno
 import gc
 import os.path
 import pytest
@@ -178,3 +179,46 @@ def test_jail_set_reads_current_buffers_under_memory_churn() -> None:
         subprocess.check_output([jail_command, "-r", str(jid)])
 
     assert len(churn) == 4096
+
+
+def test_jail_set_duplicate_raises_with_kernel_errmsg() -> None:
+    jiov = jail.Jiov({"persist": None, "path": "/rescue"})
+    jid = jail.jail_set(jiov)
+    try:
+        duplicate = jail.Jiov({"persist": None, "jid": jid, "path": "/rescue"})
+        with pytest.raises(OSError) as excinfo:
+            jail.jail_set(duplicate)
+        assert excinfo.value.errno == errno.EEXIST
+        assert f"jail {jid} already exists" == excinfo.value.strerror
+    finally:
+        jail.jail_remove(jid)
+
+
+def test_jail_remove_missing_jid_raises() -> None:
+    with pytest.raises(OSError) as excinfo:
+        jail.jail_remove(999999)
+    assert excinfo.value.errno == errno.EINVAL
+
+
+def test_jail_attach_missing_jid_raises() -> None:
+    with pytest.raises(OSError) as excinfo:
+        jail.jail_attach(999999)
+    assert excinfo.value.errno == errno.EINVAL
+
+
+def test_jail_attach_moves_child_process_root() -> None:
+    jiov = jail.Jiov({"persist": None, "name": "test-attach", "path": "/rescue"})
+    jid = jail.jail_set(jiov)
+    try:
+        child_code = "; ".join([
+            "import os",
+            "import jail",
+            f"jail.jail_attach({jid})",
+            # inside the jail /rescue is the crunchgen master binary,
+            # not the host directory the jail is rooted at
+            "assert os.path.isdir('/rescue') is False",
+            "assert os.path.isfile('/sh') is True"
+        ])
+        subprocess.run([sys.executable, "-c", child_code], check=True)
+    finally:
+        jail.jail_remove(jid)


### PR DESCRIPTION
Failures were only visible as negative return codes and an errmsg buffer nobody was required to check.

- New jail_set, jail_get, jail_attach and jail_remove wrappers raise OSError carrying errno and, where a Jiov is involved, the errmsg the kernel filled in — "jail 5 already exists" instead of a
generic message.
- jail_attach is wrapped for the first time; a test attaches a child process to a fresh jail and checks that its root moved.
- The JAIL_CREATE, JAIL_UPDATE, JAIL_ATTACH and JAIL_DYING constants replace the magic flag numbers.
- get_jid_by_name and is_jid_dying keep returning -1 and False for missing jails and raise for every other failure; raw jail.dll access stays available.